### PR TITLE
Remove cert config from compose: do it on nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,9 @@ services:
     hostname: 'ghidra.infrid.test'
     environment:
       - TERM=xterm-256color
-      - "GHIDRA_CERT_PASSWORD=$GHIDRA_CERT_PASSWORD"
     ports:
       - '13100:13100'
       - '13101:13101'
       - '13102:13102'
     volumes:
       - './volumes/repo:/srv/repositories:'
-      - './volumes/cert:/opt/ghidra/cert:'


### PR DESCRIPTION
Avoid CERT in docker, we can use NGINX to handle it.