### PR TITLE
Ghidra 10.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 # loadwordteam/ghidra-server
 ARG ghidra_install_path=/opt/ghidra
 
-# We need an OpenJDK11 image NOT based on alpine (or anything with
+# We need an OpenJDK17 image NOT based on alpine (or anything with
 # musl libc), this server has problems even with the ARM JVM, let's
 # use a very boring flavour.
-FROM openjdk:11-jdk AS builder
+FROM openjdk:17-jdk-bullseye AS builder
 
 ARG ghidra_install_path
-ARG ghidra_url=https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.1.1_build/ghidra_10.1.1_PUBLIC_20211221.zip
-ARG ghidra_sha256=d4ee61ed669cec7e20748462f57f011b84b1e8777b327704f1646c0d47a5a0e8
-ARG ghidra_version=10.1.1_PUBLIC
+ARG ghidra_url=https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.2.2_build/ghidra_10.2.2_PUBLIC_20221115.zip
+ARG ghidra_sha256=feb8a795696b406ad075e2c554c80c7ee7dd55f0952458f694ea1a918aa20ee3
+ARG ghidra_version=10.2.2_PUBLIC
 ARG ghidra_repo_path=/srv/repositories
 
 ENV LANG=C.UTF-8 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ghidra_install_path=/opt/ghidra
 # We need an OpenJDK17 image NOT based on alpine (or anything with
 # musl libc), this server has problems even with the ARM JVM, let's
 # use a very boring flavour.
-FROM openjdk:17-jdk-bullseye AS builder
+FROM debian:bullseye-slim AS builder
 
 ARG ghidra_install_path
 ARG ghidra_url=https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.2.2_build/ghidra_10.2.2_PUBLIC_20221115.zip
@@ -18,11 +18,13 @@ ENV LANG=C.UTF-8 \
 
 ADD $ghidra_url ghidra.zip
 
-RUN apt-get -qq update \
-    && apt-get -y install \
+RUN apt -qq update \
+    && apt -y install \
         locales \
         gettext-base \ 
         ncat \
+        openjdk-17-jre-headless \
+        unzip \
     && echo "${ghidra_sha256} ghidra.zip" | sha256sum -c \
     && unzip -qo ghidra.zip \
     && rm ghidra.zip \

--- a/server.conf.tmpl
+++ b/server.conf.tmpl
@@ -17,9 +17,6 @@ wrapper.java.umask=027
 # Java Classpath
 include=${classpath_frag}
 
-# Java Library Path (location of native authentication support libraries)
-wrapper.java.library.path.1=${os_dir}
-
 # Java Additional Parameters
 wrapper.java.additional.1=-Djava.net.preferIPv4Stack=true
 
@@ -29,35 +26,37 @@ wrapper.java.additional.2=-DApplicationRollingFileAppender.maxBackupIndex=10
 # Ensure that classpath_frag is defined for service startup
 wrapper.java.additional.3=-Dclasspath_frag=${classpath_frag}
 
-# If you really feel up to tunnel the RMI connection in HTTP
-# wrapper.java.additional.4=-Dhttp.proxyHost
+# Limit server to specific TLS protocols for all secure connections.
+# NOTE: multiple protocols must be separated with a semi-colon (e.g., TLSv1.2;TLSv1.3).
+wrapper.java.additional.4=-Dghidra.tls.server.protocols=TLSv1.2;TLSv1.3
+
 # A suitable cacerts file must be installed when using PKI authentication
-#wrapper.java.additional.4=-Dghidra.cacerts=./Ghidra/cacerts
+#wrapper.java.additional.5=-Dghidra.cacerts=./Ghidra/cacerts
 
 # If Ghidra clients must authenticate the server, the server will need to install
-# a server key/certificate in a secure location (e.g., /etc/pki/...)
+# a server key/certificate in a secure location (e.g., /etc/pki/...) 
 # and specify the location and password via the properties below.
 # Be sure to properly set permissions on the Ghidra installation and this file
 # if using these settings.
-wrapper.java.additional.5=-Dghidra.keystore=${GHIDRA_CERT_PATH}/keystore.jks
-wrapper.java.additional.6=-Dghidra.password=${GHIDRA_CERT_PASSWORD}
+wrapper.java.additional.6=-Dghidra.keystore=${GHIDRA_CERT_PATH}/keystore.jks
+wrapper.java.additional.7=-Dghidra.password=${GHIDRA_CERT_PASSWORD}
 
 # Temporary Directory Setting - uncomment the following setting to override the Java default.
 # This may be necessary on certain Windows platforms when installing as a service.
-#wrapper.java.additional.7=-Djava.io.tmpdir=C:\\Windows\\Temp
+#wrapper.java.additional.8=-Djava.io.tmpdir=C:\\Windows\\Temp
 
 # Enable/Disable use of compression for DataBuffer serialization and Block Streams
-wrapper.java.additional.8=-Ddb.buffers.DataBuffer.compressedOutput=true
+wrapper.java.additional.9=-Ddb.buffers.DataBuffer.compressedOutput=true
 
 # Uncomment to enable remote debug support
 # The debug address will listen on all network interfaces, if desired the '*' may be
 # set to a specific interface IP address (e.g., 127.0.0.1) if you wish to restrict.
 # During debug it may be necessary to increase timeout values to prevent the wrapper
 # from restarting the server due to unresponsiveness.
-#wrapper.java.additional.9=-Xdebug
-#wrapper.java.additional.10=-Xnoagent
-#wrapper.java.additional.11=-Djava.compiler=NONE
-#wrapper.java.additional.12=-Xrunjdwp:transport=dt_socket\,server=y\,suspend=n\,address=*:18200
+#wrapper.java.additional.10=-Xdebug
+#wrapper.java.additional.11=-Xnoagent
+#wrapper.java.additional.12=-Djava.compiler=NONE
+#wrapper.java.additional.13=-Xrunjdwp:transport=dt_socket\,server=y\,suspend=n\,address=*:18200
 #wrapper.startup.timeout=0
 #wrapper.ping.timeout=0
 
@@ -68,14 +67,14 @@ wrapper.java.additional.8=-Ddb.buffers.DataBuffer.compressedOutput=true
 
 # Uncomment to enable remote use of jvisualvm for profiling
 # See JMX documentation for more information: http://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html
-#wrapper.java.additional.13=-Dcom.sun.management.jmxremote.port=9010
-#wrapper.java.additional.14=-Dcom.sun.management.jmxremote.local.only=false
-#wrapper.java.additional.15=-Dcom.sun.management.jmxremote.authenticate=false
-#wrapper.java.additional.16=-Dcom.sun.management.jmxremote.ssl=false
+#wrapper.java.additional.14=-Dcom.sun.management.jmxremote.port=9010
+#wrapper.java.additional.15=-Dcom.sun.management.jmxremote.local.only=false
+#wrapper.java.additional.16=-Dcom.sun.management.jmxremote.authenticate=false
+#wrapper.java.additional.17=-Dcom.sun.management.jmxremote.ssl=false
 
-# YAJSW will by default assume a POSIX spawn for Linux and Mac OS X systems, unfortunately it has
-# not yet been implemented for Mac OS X.  The default process support within YAJSW for Mac OS X is
-# broken so we must force the use of BSD process support which appears to work properly.  To enable
+# YAJSW will by default assume a POSIX spawn for Linux and Mac OS X systems, unfortunately it has 
+# not yet been implemented for Mac OS X.  The default process support within YAJSW for Mac OS X is 
+# broken so we must force the use of BSD process support which appears to work properly.  To enable 
 # this mode of operation the wrapper.fork_hack option must be enabled and the wrapper.posix_spawn
 # option explicitly disabled.  The ghidraSvr script will attempt to make these changes automatically
 # for Mac OS X.
@@ -97,29 +96,29 @@ wrapper.java.initmemory=396
 # See svrREADME.txt file for advice (Server Memory Considerations)
 wrapper.java.maxmemory=768
 
-# Specify the directory used to store repositories. This directory must be dedicated to this
-# Ghidra Server instance and may not contain files or folders not produced by the
-# Ghidra Server or its administrative scripts.  Relative paths originate from the
+# Specify the directory used to store repositories. This directory must be dedicated to this 
+# Ghidra Server instance and may not contain files or folders not produced by the 
+# Ghidra Server or its administrative scripts.  Relative paths originate from the 
 # Ghidra installation directory, although an absolute path is preferred if not using default.
 # This variable is also used by the svrAdmin script.
 
 ghidra.repositories.dir=${GHIDRA_REPO_DIR}
 
-# Ghidra server startup parameters.
+# Ghidra server startup parameters.  
 #
 # Command line parameters: (Add command line parameters as needed and renumber each starting from .1)
 #						[-ip <hostname>] [-i #.#.#.#] [-p#] [-n]
 #						[-a#] [-d<ad_domain>] [-e<days>] [-jaas <config_file>] [-u] [-autoProvision] [-anonymous] [-ssh]
 #						<repository_path>
 #
-#   -ip <hostname> : identifies the remote access IPv4 address or hostname (FQDN) which should be
+#   -ip <hostname> : identifies the remote access IPv4 address or hostname (FQDN) which should be 
 #   	                used by remote clients to access the server.
-#
+#   	                 
 #   -i #.#.#.# : server interface IPv4 address to listen on (default will listen on all interfaces).
-#
+#	
 #   -p# : base TCP port to be used (default: 13100) [see Note 1]
-#
-#   -n   : enable reverse name lookup for IP addresses when logging (requires proper configuration
+#   
+#   -n   : enable reverse name lookup for IP addresses when logging (requires proper configuration 
 #          of reverse lookup by your DNS server)
 #
 #   -a# : an optional authentication mode where # is a value of 0, 1, 2, or 4
@@ -127,33 +126,33 @@ ghidra.repositories.dir=${GHIDRA_REPO_DIR}
 #         1 - Active Directory via Kerberos.  Requires -d<your.ad_domainname.tld>
 #         2 - PKI Authentication
 #         4 - JAAS Authentication.  See also -jaas <config_file>
-#
+#         
 #   -d<ad_domain> : the Active Directory domain name.  Example: "-dmydomain.com"
-#
+# 
 #   -e<days> : specifies initial/reset password expiration time in days (-a0 mode only, default is 1-day, 0 = no expiration)
 #
 #   -jaas <config_file> : specifies the path to the JAAS config file (when using -a4), relative
 #                         to the ghidra/server directory (if not absolute).
 #                         See jaas.conf for examples and suggestions.
-#                         It is the system administrator's responsibility to craft their own
+#                         It is the system administrator's responsibility to craft their own 
 #                         JAAS configuration directive when using the -a4 mode.
-#
+#   
 #   -u   : enable users to be prompted for user ID (does not apply to -a2 PKI mode)
-#
+#   
 #   -autoProvision : enable the auto-creation of new Ghidra Server
 #                    users when they successfully authenticate to the server (-a1 and -a4 modes only).
 #                    Users removed from the authentication provider (e.g., Active Directory) will need to be
 #                    deleted manually from the Ghidra Server using svrAdmin command.
 #
 #   -anonymous : enables anonymous repository access (see svrREADME.html for details)
-#
+# 
 #   -ssh : enables SSH authentication for headless clients
 #
-#   <repository_path> : Required.  Directory used to store repositories. This directory must be dedicated to this
+#   <repository_path> : Required.  Directory used to store repositories. This directory must be dedicated to this 
 #                       Ghidra Server instance and may not contain files or folders not produced
 #                       by the Ghidra Server or its administrative scripts.
 #                       Relative paths originate from the installation directory
-#   ${ghidra.repositories.dir} : config variable (defined above) which identifies the directory
+#   ${ghidra.repositories.dir} : config variable (defined above) which identifies the directory 
 #                       used to store repositories.  Use of this variable to define the
 #                       repositories directory must be retained.
 wrapper.app.parameter.1=-a0
@@ -200,6 +199,12 @@ wrapper.logfile.maxsize=10m
 wrapper.logfile.maxfiles=10
 
 #********************************************************************
+# Service Wrapper Linux Properties
+#********************************************************************
+# Force initd (systemd had issues during testing on Ubuntu 21.04 with yajsw-13.00)
+#wrapper.daemon.system = initd
+
+#********************************************************************
 # Service Wrapper Windows Properties
 #********************************************************************
 # Title to use when running as a console
@@ -225,13 +230,13 @@ wrapper.ntservice.description=Repository server for Ghidra data files.
 # Service dependencies.  Add dependencies as needed starting from 1
 wrapper.ntservice.dependency.1=
 
-# Mode in which the service is installed.
+# Mode in which the service is installed.  
 wrapper.ntservice.starttype=AUTO_START
 
 # Linux service daemon priority for Ghidra Server (start/stop)
 # It is important that the network interface has started and any file-system
 # dependencies are mounted prior to the Ghidra Server starting.
-# NOTE: uninstall the Ghidra Server service using svrUninstall script before changing
+# NOTE: uninstall the Ghidra Server service using svrUninstall script before changing 
 # the property wrapper.daemon.update_rc or wrapper.daemon.run_level_dir property.
 wrapper.daemon.update_rc= 98 05
 


### PR DESCRIPTION
* Update to Ghidra 10.2.2
    This also updates the container to OpenJDK 17 which is now mandatory
    for Ghidra 10.2.2.
* Use normal Debian bullseye as base
    The OpenJDK container was not updated in 9 months, better use a standard
    Debian bullseye container and install OpenJDK from Debian.
* Sync server.conf.tmp with Ghidra 10.2.2
    This syncs the file with the version currently shipped with
    Ghidra 10.2.2.
    It also restricts it to TLSv1.2;TLSv1.3 which is the new default setting.